### PR TITLE
Don't override action in state packet; should always come from the pump

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1765,21 +1765,16 @@ void onSetMode(const char *message) {
   } else {
     if (modeUpper == "HEAT_COOL") {
       stateOverride["mode"] = "heat_cool";
-      stateOverride["action"] = "idle";
       modeUpper = "AUTO";
       // NOLINTNEXTLINE(bugprone-branch-clone) why is the next branch getting flagged as a clone?
     } else if (modeUpper == "HEAT") {
       stateOverride["mode"] = "heat";
-      stateOverride["action"] = "heating";
     } else if (modeUpper == "COOL") {
       stateOverride["mode"] = "cool";
-      stateOverride["action"] = "cooling";
     } else if (modeUpper == "DRY") {
       stateOverride["mode"] = "dry";
-      stateOverride["action"] = "drying";
     } else if (modeUpper == "FAN_ONLY") {
       stateOverride["mode"] = "fan_only";
-      stateOverride["action"] = "fan";
       modeUpper = "FAN";
     } else {
       return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,8 +258,6 @@ String ha_config_topic;
 // Customization
 
 // sketch settings
-const PROGMEM uint32_t SEND_MQTT_STATE_INTERVAL_MS =
-    30000;  // 45 seconds (anything less may cause bouncing)
 const PROGMEM uint32_t CHECK_REMOTE_TEMP_INTERVAL_MS = 300000;  // 5 minutes
 const PROGMEM uint32_t MQTT_RETRY_INTERVAL_MS = 1000;           // 1 second
 const PROGMEM uint64_t HP_RETRY_INTERVAL_MS = 1000UL;           // 1 second
@@ -1580,7 +1578,10 @@ String hpGetAction(const HeatpumpStatus &hpStatus, const HeatpumpSettings &hpSet
 }
 
 void pushHeatPumpStateToMqtt() {
-  if (millis() - lastMqttStatePacketSend > SEND_MQTT_STATE_INTERVAL_MS) {
+  // If we're not pushing optimistic updates on every incoming change, then we should send the
+  // state to MQTT at a higher cadence
+  const uint32_t interval = config.other.optimisticUpdates ? 30000UL : 10000UL;
+  if (millis() - lastMqttStatePacketSend > interval) {
     String mqttOutput;
     serializeJson(getHeatPumpStatusJson(), mqttOutput);
 


### PR DESCRIPTION
Before this PR, the heatpump would show that it was heating when it was in fact idle.

Also added a toggle for the optimistic update behavior - I'd rather just send updates to MQTT on a steady basis, since I don't use HA as an input device.