### PR TITLE
Add Moment object, eliminate rollover bugs in time interval calculation

### DIFF
--- a/lib/moment/moment.cpp
+++ b/lib/moment/moment.cpp
@@ -1,0 +1,4 @@
+#include "moment.hpp"
+
+uint32_t Moment::_rolloverCount = 0;
+uint32_t Moment::_lastValue = 0;

--- a/lib/moment/moment.hpp
+++ b/lib/moment/moment.hpp
@@ -34,6 +34,13 @@ class Moment {
     normalize();
   }
 
+  int32_t operator-(const Moment &other) const {
+    // TODO(floatplane) should eventually worry about clamping here
+    // Probably should establish a max value for a moment that fits comfortably in a 32-bit int
+    return (static_cast<int32_t>(hours) - static_cast<int32_t>(other.hours)) * millisecondsPerHour +
+           (static_cast<int32_t>(milliseconds) - static_cast<int32_t>(other.milliseconds));
+  }
+
  public:
   MomentParts get() const {
     return {

--- a/lib/moment/moment.hpp
+++ b/lib/moment/moment.hpp
@@ -1,0 +1,66 @@
+#include <cstdint>
+#include <cstdio>
+
+class Moment {
+ public:
+  struct MomentParts {
+    // ordered for packing
+    uint16_t milliseconds;
+    uint16_t days;
+    uint8_t years;
+    uint8_t hours;
+    uint8_t seconds;
+    uint8_t minutes;
+  };
+
+  static void resetRolloverCount() {
+    _rolloverCount = 0;
+    _lastValue = 0;
+  }
+
+#ifdef ARDUINO_H_INCLUDED
+ public:
+  Moment() : Moment(millis()) {
+  }
+#endif
+
+  Moment(uint32_t value) {
+    if (value < _lastValue) {
+      _rolloverCount++;
+    }
+    _lastValue = value;
+    hours = value / millisecondsPerHour + _rolloverCount * hoursPerRollover;
+    milliseconds = value % millisecondsPerHour + _rolloverCount * millisecondsPerRollover;
+    normalize();
+  }
+
+ public:
+  MomentParts get() const {
+    return {
+        .milliseconds = static_cast<uint16_t>(milliseconds % 1000UL),
+        .seconds = static_cast<uint8_t>((milliseconds / 1000UL) % 60UL),
+        .minutes = static_cast<uint8_t>(milliseconds / 1000UL / 60UL),
+        .hours = static_cast<uint8_t>(hours % 24UL),
+        .days = static_cast<uint16_t>((hours / 24UL) % 365UL),
+        .years = static_cast<uint8_t>(hours / 24UL / 365UL),
+    };
+  }
+
+ private:
+  static constexpr uint32_t millisecondsPerHour = 60UL * 60UL * 1000UL;
+  static constexpr uint32_t millisecondsPerRollover = 0xFFFFFFFFUL % millisecondsPerHour;
+  static constexpr uint32_t hoursPerRollover = 0xFFFFFFFFUL / millisecondsPerHour;
+
+  void normalize() {
+    while (milliseconds > millisecondsPerHour) {
+      milliseconds -= millisecondsPerHour;
+      hours++;
+    }
+    printf("post normalize: %u milliseconds, %u hours\n", milliseconds, hours);
+  }
+
+  uint32_t milliseconds;
+  uint32_t hours;
+  static uint32_t _rolloverCount;
+  static uint32_t _lastValue;
+};

--- a/lib/moment/moment.hpp
+++ b/lib/moment/moment.hpp
@@ -97,7 +97,7 @@ class Moment {
     never,
   };
 
-  explicit Moment([[maybe_unused]] Never never) : _milliseconds(LLONG_MIN) {
+  explicit Moment(Never /*never*/) : _milliseconds(LLONG_MIN) {
   }
 
   int64_t _milliseconds;

--- a/test/test_moment/moment.cpp
+++ b/test/test_moment/moment.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Moment") {
   }
 
   SUBCASE("test subtraction of larger values") {
-    constexpr uint32_t millisecondsPerHour = 60UL * 60UL * 1000UL;
+    constexpr auto millisecondsPerHour = 60 * 60 * 1000;
     const auto one = Moment(2 * millisecondsPerHour + 250);
     const auto two = Moment(5 * millisecondsPerHour + 600);
 

--- a/test/test_moment/moment.cpp
+++ b/test/test_moment/moment.cpp
@@ -7,53 +7,80 @@ const unsigned long MS_PER_DAY = 24 * 60 * 60 * 1000;
 const unsigned long MS_PER_HOUR = 60 * 60 * 1000;
 const unsigned long MS_PER_MINUTE = 60 * 1000;
 
-TEST_CASE("test construction and reading back values") {
+TEST_CASE("Moment") {
   Moment::resetRolloverCount();
-  const auto one = Moment(1000).get();
-  CHECK(one.milliseconds == 0);
-  CHECK(one.seconds == 1);
-  CHECK(one.minutes == 0);
-  CHECK(one.hours == 0);
-  CHECK(one.days == 0);
-  CHECK(one.years == 0);
 
-  unsigned long value = 2 * MS_PER_DAY + 3 * MS_PER_HOUR + 4 * MS_PER_MINUTE + 5678;
-  const auto two = Moment(2 * MS_PER_DAY + 3 * MS_PER_HOUR + 4 * MS_PER_MINUTE + 5678).get();
-  CHECK(two.milliseconds == 678);
-  CHECK(two.seconds == 5);
-  CHECK(two.minutes == 4);
-  CHECK(two.hours == 3);
-  CHECK(two.days == 2);
-  CHECK(two.years == 0);
+  SUBCASE("test construction and reading back values") {
+    const auto one = Moment(1000).get();
+    CHECK(one.milliseconds == 0);
+    CHECK(one.seconds == 1);
+    CHECK(one.minutes == 0);
+    CHECK(one.hours == 0);
+    CHECK(one.days == 0);
+    CHECK(one.years == 0);
 
-  uint32_t maxValue = 0xFFFFFFFF;
-  const auto three = Moment(maxValue).get();
-  CHECK(three.milliseconds == 295);
-  CHECK(three.seconds == 47);
-  CHECK(three.minutes == 2);
-  CHECK(three.hours == 17);
-  CHECK(three.days == 49);
-  CHECK(three.years == 0);
-}
+    unsigned long value = 2 * MS_PER_DAY + 3 * MS_PER_HOUR + 4 * MS_PER_MINUTE + 5678;
+    const auto two = Moment(2 * MS_PER_DAY + 3 * MS_PER_HOUR + 4 * MS_PER_MINUTE + 5678).get();
+    CHECK(two.milliseconds == 678);
+    CHECK(two.seconds == 5);
+    CHECK(two.minutes == 4);
+    CHECK(two.hours == 3);
+    CHECK(two.days == 2);
+    CHECK(two.years == 0);
 
-TEST_CASE("handling rollover") {
-  Moment::resetRolloverCount();
-  const auto before = Moment(2000).get();
-  const auto after = Moment(1000).get();
+    uint32_t maxValue = 0xFFFFFFFF;
+    const auto three = Moment(maxValue).get();
+    CHECK(three.milliseconds == 295);
+    CHECK(three.seconds == 47);
+    CHECK(three.minutes == 2);
+    CHECK(three.hours == 17);
+    CHECK(three.days == 49);
+    CHECK(three.years == 0);
+  }
 
-  CHECK(before.milliseconds == 0);
-  CHECK(before.seconds == 2);
-  CHECK(before.minutes == 0);
-  CHECK(before.hours == 0);
-  CHECK(before.days == 0);
-  CHECK(before.years == 0);
+  SUBCASE("handling rollover") {
+    const auto before = Moment(2000).get();
+    const auto after = Moment(1000).get();
 
-  CHECK(after.milliseconds == 295);
-  CHECK(after.seconds == 47 + 1);
-  CHECK(after.minutes == 2);
-  CHECK(after.hours == 17);
-  CHECK(after.days == 49);
-  CHECK(after.years == 0);
+    CHECK(before.milliseconds == 0);
+    CHECK(before.seconds == 2);
+    CHECK(before.minutes == 0);
+    CHECK(before.hours == 0);
+    CHECK(before.days == 0);
+    CHECK(before.years == 0);
+
+    CHECK(after.milliseconds == 295);
+    CHECK(after.seconds == 47 + 1);
+    CHECK(after.minutes == 2);
+    CHECK(after.hours == 17);
+    CHECK(after.days == 49);
+    CHECK(after.years == 0);
+  }
+
+  SUBCASE("test basic subtraction") {
+    const auto one = Moment(1000);
+    const auto two = Moment(2000);
+
+    CHECK(one - two == -1000);
+    CHECK(two - one == 1000);
+  }
+
+  SUBCASE("test subtraction of larger values") {
+    constexpr uint32_t millisecondsPerHour = 60UL * 60UL * 1000UL;
+    const auto one = Moment(2 * millisecondsPerHour + 250);
+    const auto two = Moment(5 * millisecondsPerHour + 600);
+
+    CHECK(one - two == -3 * millisecondsPerHour - 350);
+    CHECK(two - one == 3 * millisecondsPerHour + 350);
+  }
+
+  SUBCASE("test subtraction with rollover") {
+    const auto one = Moment(0xffffffff - 1000);
+    const auto two = Moment(500);
+
+    CHECK(one - two == -1500);
+    CHECK(two - one == 1500);
+  }
 }
 
 int main(int argc, char **argv) {

--- a/test/test_moment/moment.cpp
+++ b/test/test_moment/moment.cpp
@@ -1,0 +1,71 @@
+#define DOCTEST_CONFIG_IMPLEMENT  // REQUIRED: Enable custom main()
+#include "moment.hpp"
+
+#include <doctest.h>
+
+const unsigned long MS_PER_DAY = 24 * 60 * 60 * 1000;
+const unsigned long MS_PER_HOUR = 60 * 60 * 1000;
+const unsigned long MS_PER_MINUTE = 60 * 1000;
+
+TEST_CASE("test construction and reading back values") {
+  Moment::resetRolloverCount();
+  const auto one = Moment(1000).get();
+  CHECK(one.milliseconds == 0);
+  CHECK(one.seconds == 1);
+  CHECK(one.minutes == 0);
+  CHECK(one.hours == 0);
+  CHECK(one.days == 0);
+  CHECK(one.years == 0);
+
+  unsigned long value = 2 * MS_PER_DAY + 3 * MS_PER_HOUR + 4 * MS_PER_MINUTE + 5678;
+  const auto two = Moment(2 * MS_PER_DAY + 3 * MS_PER_HOUR + 4 * MS_PER_MINUTE + 5678).get();
+  CHECK(two.milliseconds == 678);
+  CHECK(two.seconds == 5);
+  CHECK(two.minutes == 4);
+  CHECK(two.hours == 3);
+  CHECK(two.days == 2);
+  CHECK(two.years == 0);
+
+  uint32_t maxValue = 0xFFFFFFFF;
+  const auto three = Moment(maxValue).get();
+  CHECK(three.milliseconds == 295);
+  CHECK(three.seconds == 47);
+  CHECK(three.minutes == 2);
+  CHECK(three.hours == 17);
+  CHECK(three.days == 49);
+  CHECK(three.years == 0);
+}
+
+TEST_CASE("handling rollover") {
+  Moment::resetRolloverCount();
+  const auto before = Moment(2000).get();
+  const auto after = Moment(1000).get();
+
+  CHECK(before.milliseconds == 0);
+  CHECK(before.seconds == 2);
+  CHECK(before.minutes == 0);
+  CHECK(before.hours == 0);
+  CHECK(before.days == 0);
+  CHECK(before.years == 0);
+
+  CHECK(after.milliseconds == 295);
+  CHECK(after.seconds == 47 + 1);
+  CHECK(after.minutes == 2);
+  CHECK(after.hours == 17);
+  CHECK(after.days == 49);
+  CHECK(after.years == 0);
+}
+
+int main(int argc, char **argv) {
+  doctest::Context context;
+
+  // BEGIN:: PLATFORMIO REQUIRED OPTIONS
+  context.setOption("success", true);      // Report successful tests
+  context.setOption("no-exitcode", true);  // Do not return non-zero code on failed test case
+  // END:: PLATFORMIO REQUIRED OPTIONS
+
+  // YOUR CUSTOM DOCTEST OPTIONS
+
+  context.applyCommandLine(argc, argv);
+  return context.run();
+}

--- a/test/test_moment/moment.cpp
+++ b/test/test_moment/moment.cpp
@@ -57,6 +57,28 @@ TEST_CASE("Moment") {
     CHECK(after.years == 0);
   }
 
+  SUBCASE("assignment with rollover") {
+    auto moment = Moment(0);
+
+    moment = Moment(2000);
+    const auto before = moment.get();
+    CHECK(before.milliseconds == 0);
+    CHECK(before.seconds == 2);
+    CHECK(before.minutes == 0);
+    CHECK(before.hours == 0);
+    CHECK(before.days == 0);
+    CHECK(before.years == 0);
+
+    moment = Moment(1000);
+    const auto after = moment.get();
+    CHECK(after.milliseconds == 295);
+    CHECK(after.seconds == 47 + 1);
+    CHECK(after.minutes == 2);
+    CHECK(after.hours == 17);
+    CHECK(after.days == 49);
+    CHECK(after.years == 0);
+  }
+
   SUBCASE("test basic subtraction") {
     const auto one = Moment(1000);
     const auto two = Moment(2000);
@@ -80,6 +102,46 @@ TEST_CASE("Moment") {
 
     CHECK(one - two == -1500);
     CHECK(two - one == 1500);
+  }
+
+  SUBCASE("increment and decrement") {
+    auto moment = Moment(1000 * 60 * 60 * 24);
+    CHECK(moment.get().days == 1);
+    CHECK(moment.get().hours == 0);
+    moment.offset(1000 * 60 * 60 * 24);
+    CHECK(moment.get().days == 2);
+    CHECK(moment.get().hours == 0);
+    moment.offset(-1000 * 60 * 60 * 12);
+    CHECK(moment.get().days == 1);
+    CHECK(moment.get().hours == 12);
+  }
+
+  SUBCASE("comparison") {
+    const auto one = Moment(1000);
+    const auto three = Moment(1000);
+    const auto two = Moment(2000);
+
+    CHECK_UNARY(one != two);
+    CHECK_UNARY(one < two);
+    CHECK_UNARY(two > one);
+    CHECK_UNARY(one <= two);
+    CHECK_UNARY(two >= one);
+
+    CHECK_UNARY(one == three);
+    CHECK_UNARY(one <= three);
+    CHECK_UNARY(one >= three);
+  }
+
+  SUBCASE("test subtraction against never()") {
+    const auto lastOccurrence = Moment::never();
+    const auto now = Moment(1000);
+
+    // Not sure I love this behavior, but at least it's codified in a test
+    CHECK(lastOccurrence - now == -1000);
+    CHECK(now - lastOccurrence == LLONG_MAX);
+
+    // Verify that this common usage works as intended
+    CHECK_UNARY(now - lastOccurrence > 500000);
   }
 }
 


### PR DESCRIPTION
The previous code for interval checking was prone to errors, given that the 32-bit arduino `millis()` function rolls over relatively frequently - this just makes that class of errors impossible.