### PR TITLE
Fix reboot loop with remote temperature/safe mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -294,7 +294,7 @@ Moment lastMqttRetry(Moment::never());
 Moment lastHpSync(Moment::never());
 unsigned int hpConnectionRetries;
 unsigned int hpConnectionTotalRetries;
-Moment lastRemoteTemp(Moment::never());
+Moment lastRemoteTemp(Moment::now());
 
 // Web OTA
 enum UploadError {


### PR DESCRIPTION
I think the reboot loop problem was caused by trying to set turn power off before calling hp.sync(). But basically, we shouldn't start in a "remoteTempStale" state - we want to let the system come up before making that determination.