### PR TITLE
control template expects power to be boolean

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -962,7 +962,7 @@ void handleControlGet() {
   data[F("temp_step")] = config.unit.tempStep;
   data[F("temp_unit")] = config.unit.tempUnit == TempUnit::C ? "C" : "F";
   data[F("supportHeatMode")] = config.unit.supportHeatMode;
-  data[F("power")] = settings.power;
+  data[F("power")] = settings.power == "ON";
 
   const auto mode = data[F("mode")].to<JsonObject>();
   mode[F("cool")] = settings.mode == "COOL";


### PR DESCRIPTION
Hello, I had trouble with the control page reflecting the correct power status of the unit. It would appear the `power` variable is being sent as a string `(ON|OFF)` but the template is expecting a boolean. This pr corrects the behavior to be consistent with the output in the metrics template.