### PR TITLE
update ref to ESPAsyncWebServer

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -66,7 +66,7 @@ framework = arduino
 extends = common
 lib_deps = 
 	${common.lib_deps}
-	me-no-dev/ESP Async WebServer@1.2.3
+	ESP32Async/ESPAsyncWebServer @ 3.6.0
 
 ;
 ; Build settings shared across all ESP32 targets. These are appended to or overridden by the target-specific settings.
@@ -83,9 +83,7 @@ build_flags =
 	-D CORE_DEBUG_LEVEL=0
 lib_deps = 
 	${common.lib_deps}
-	; latest master required for ESP32 because released version causes linker failures
-	; https://github.com/me-no-dev/ESPAsyncWebServer/pull/999
-	https://github.com/me-no-dev/ESPAsyncWebServer.git
+	ESP32Async/ESPAsyncWebServer @ 3.6.0
 
 ;
 ; ESP8266 targets


### PR DESCRIPTION
A fresh build is failing because the repo `me-no-dev/ESPAsyncWebServer @ 1.2.3` has been archived. This pr changes the references to the updated repo.